### PR TITLE
Bump jQuery.Validation from 1.17.0 to 1.19.3 in /CRUDDemo

### DIFF
--- a/CRUDDemo/packages.config
+++ b/CRUDDemo/packages.config
@@ -4,7 +4,7 @@
   <package id="bootstrap" version="3.4.1" targetFramework="net472" />
   <package id="EntityFramework" version="6.2.0" targetFramework="net472" />
   <package id="jQuery" version="3.4.1" targetFramework="net472" />
-  <package id="jQuery.Validation" version="1.17.0" targetFramework="net472" />
+  <package id="jQuery.Validation" version="1.19.3" targetFramework="net472" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.7" targetFramework="net472" />
   <package id="Microsoft.AspNet.Razor" version="3.2.7" targetFramework="net472" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net472" />


### PR DESCRIPTION
Bumps jQuery.Validation from 1.17.0 to 1.19.3.

---
updated-dependencies:
- dependency-name: jQuery.Validation dependency-type: direct:production ...